### PR TITLE
Ensure the room contains an item before taking

### DIFF
--- a/src/Engine/Engine.ts
+++ b/src/Engine/Engine.ts
@@ -120,10 +120,14 @@ export class Engine {
                     // Try the room
                     let item = Utilities.FindItemInList(this.config.player.location.items, command.args[0])
                     if (item != null && item.take.canTake) {
-                        this.config.player.location.items.splice(this.config.player.location.items.indexOf(item), 1);
-                        this.config.player.inventory.push(item);
-                        this.out.Print("Took the " + item.name + ".");
-                        break;
+                        let itemIndex = this.config.player.location.items.indexOf(item);
+                        //ensure the room contains this item
+                        if (itemIndex > -1){
+                            this.config.player.location.items.splice(itemIndex, 1);
+                            this.config.player.inventory.push(item);
+                            this.out.Print("Took the " + item.name + ".");
+                            break;
+                        }
                     } else if (item != null) {
                         this.out.Print("That can't be taken.");
                         break;


### PR DESCRIPTION
It's possible to take the leaflet multiple times because the Take command first searches the room using FindItemByName. This also will find a sub-item such as the leaflet, but then splicing the room items with the index of the item (-1 in this case) will not work (and as a side-effect will actually delete the last room item!!).
I just added a simple check to see if the index is indeed -1 and fall through to the next search in that case.